### PR TITLE
sets scroll to top if a new marker cluster is clicked

### DIFF
--- a/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
+++ b/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
@@ -1,7 +1,7 @@
 ;(function( $ ) {
 
   $.fn.blacklight_leaflet_map = function(geojson_docs, arg_opts) {
-    var map, sidebar, markers, geoJsonLayer;
+    var map, sidebar, markers, geoJsonLayer, currentLayer;
 
     // Configure default options and those passed via the constructor options
     var options = $.extend({
@@ -78,12 +78,18 @@
     function setupSidebarDisplay(e, placenames){
       hideSidebar();
       offsetMap(e);
+      if (currentLayer !== e.layer || !("layer" in e)){
+        // Update sidebar div with new html
+        $('#' + options.sidebar).html(buildList(placenames));
 
-      // Update sidebar div with new html
-      $('#' + options.sidebar).html(buildList(placenames));
+        // Scroll sidebar div to top
+        $('#' + options.sidebar).scrollTop(0);
+        currentLayer = e.layer;
+      }
 
       // Show the sidebar
       sidebar.show();
+
     }
 
     // Hides sidebar if it is visible


### PR DESCRIPTION
When a user clicks onto a new markercluster point, the scroll is set to the top of the sidebar div.  When a user clicks onto a new markercluster their scroll position is preserved.

Tested and works in Maps of Africa

Fixes #15 
