### PR TITLE
remove public exposure of private methods in spec, using send instead, fixes #31

### DIFF
--- a/spec/lib/blacklight/maps/export_spec.rb
+++ b/spec/lib/blacklight/maps/export_spec.rb
@@ -2,10 +2,6 @@ require 'spec_helper'
 
 describe "BlacklightMaps::GeojsonExport" do
 
-  class BlacklightMaps::GeojsonExport
-    public :blacklight_maps_config, :type, :placename_coord_field, :placename_coord_delimiter, :bbox_field, :build_point_feature, :build_bbox_features, :render_leaflet_sidebar_partial
-  end
-
   before do
     CatalogController.blacklight_config = Blacklight::Configuration.new
     CatalogController.configure_blacklight do |config|
@@ -29,40 +25,40 @@ describe "BlacklightMaps::GeojsonExport" do
   end
 
   it "should return maps config" do
-    expect(subject.blacklight_maps_config.class).to eq(::Blacklight::Configuration::ViewConfig)
+    expect(subject.send(:blacklight_maps_config).class).to eq(::Blacklight::Configuration::ViewConfig)
   end
 
   it "should return type" do
-    expect(subject.type).to eq('placename_coord')
+    expect(subject.send(:type)).to eq('placename_coord')
   end
 
   it "should return placename field" do
-    expect(subject.placename_coord_field).to eq('placename_coords')
+    expect(subject.send(:placename_coord_field)).to eq('placename_coords')
   end
 
   it "should return placename delimiter" do
-    expect(subject.placename_coord_delimiter).to eq('-|-')
+    expect(subject.send(:placename_coord_delimiter)).to eq('-|-')
   end
 
   it "should return bbox field" do
-    expect(subject.bbox_field).to eq('place_bbox')
+    expect(subject.send(:bbox_field)).to eq('place_bbox')
   end
 
   it "should return point feature with no properties" do
-    expect(subject.build_point_feature(100, -50)).to eq({:type=>"Feature", :geometry=>{:type=>"Point", :coordinates=>[100.0, -50.0]}, :properties=>{}})
+    expect(subject.send(:build_point_feature, 100, -50)).to eq({:type=>"Feature", :geometry=>{:type=>"Point", :coordinates=>[100.0, -50.0]}, :properties=>{}})
   end
 
   it "should return point feature with properties" do
-    expect(subject.build_point_feature(100, -50, { name: 'Jane Smith' })[:properties]).to have_key(:name)
+    expect(subject.send(:build_point_feature, 100, -50, { name: 'Jane Smith' })[:properties]).to have_key(:name)
   end
 
   it "should build bbox correct features" do
-    expect(subject.build_bbox_features.length).to eq(1)
-    expect(subject.build_bbox_features[0][:geometry][:type]).to eq('Point')
+    expect(subject.send(:build_bbox_features).length).to eq(1)
+    expect(subject.send(:build_bbox_features)[0][:geometry][:type]).to eq('Point')
   end
 
   it "should render correct sidebar div" do
-    expect(subject.render_leaflet_sidebar_partial(@response.docs[0])).to include('href="/catalog/2008308478">')
+    expect(subject.send(:render_leaflet_sidebar_partial, @response.docs[0])).to include('href="/catalog/2008308478">')
   end
 
   it "should render feature collection as json" do


### PR DESCRIPTION
Thanks @jcoyne and @jkeck for the suggestions.  Modeled after:

https://github.com/sul-dlss/spotlight/blob/master/spec/helpers/spotlight/crud_link_helpers_spec.rb#L122
