### PR TITLE
adds logging message for unknown type

### DIFF
--- a/lib/blacklight/maps/export.rb
+++ b/lib/blacklight/maps/export.rb
@@ -49,6 +49,8 @@ module BlacklightMaps
         build_placename_coord_features
       when 'bbox'
         build_bbox_features
+      else
+        Rails.logger.error("Your Solr field type was not configured with a recognized type, '#{type}' is not yet supported")
       end
     end
 


### PR DESCRIPTION
Fixes #29 

I think that a logger message is more appropriate than an exception.

per comment from @jkeck 
