### PR TITLE
enabled multivalued bbox support fixes #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Blacklight-Maps adds a map view capability for a results set that contains geosp
 
 For now, Blacklight-Maps requires that your Solr index include one of the following two types of fields:
 
-1. A `location_rpt` field that contains a bounding box for the document.  For more on `location_rpt` see [Solr help](https://cwiki.apache.org/confluence/display/solr/Spatial+Search)
+1. A `location_rpt` field that contains a bounding box for the document.  For more on `location_rpt` see [Solr help](https://cwiki.apache.org/confluence/display/solr/Spatial+Search). This field can be multivalued.
 ```
   place_bbox: 44.0318907 25.0594286 63.3333366 39.7816755
               # minX minY maxX maxY

--- a/lib/blacklight/maps/export.rb
+++ b/lib/blacklight/maps/export.rb
@@ -73,10 +73,12 @@ module BlacklightMaps
       features = []
       @response_docs.each do |doc|
         next if doc[bbox_field].nil?
-        lnglat = Geometry::BoundingBox.from_lon_lat_string(doc[bbox_field]).find_center
-        features.push(
-          build_point_feature(lnglat[0], lnglat[1],
-                              html: render_leaflet_sidebar_partial(doc)))
+        doc[bbox_field].uniq.each do |loc|
+          lnglat = Geometry::BoundingBox.from_lon_lat_string(loc).find_center
+          features.push(
+            build_point_feature(lnglat[0], lnglat[1],
+                                html: render_leaflet_sidebar_partial(doc)))
+        end
       end
       features
     end

--- a/solr_conf/conf/schema.xml
+++ b/solr_conf/conf/schema.xml
@@ -579,7 +579,7 @@
    <dynamicField name="*spell" type="textSpell" indexed="true" stored="false" multiValued="true" />
 
    <dynamicField name="*_pt"     type="location"     stored="true" indexed="true"/>
-   <dynamicField name="*_bbox"   type="location_rpt" stored="true" indexed="true"/>
+   <dynamicField name="*_bbox"   type="location_rpt" stored="true" indexed="true" multiValued="true"/>
 
    <!-- uncomment the following to ignore any fields that don't already match an existing
         field name or dynamic field, rather than reporting them as an error.

--- a/spec/features/maps_spec.rb
+++ b/spec/features/maps_spec.rb
@@ -91,10 +91,10 @@ describe "Map View", js: true do
       end
     end
 
-    before { visit catalog_index_path :q => 'tibet', :view => 'maps' }
+    before { visit catalog_index_path :q => 'korea', :view => 'maps' }
 
-    it "should have 2 markers" do
-      expect(find("div.marker-cluster")).to have_content(2)
+    it "should have 4 markers" do
+      expect(find("div.marker-cluster")).to have_content(4)
     end
 
     describe "click marker cluster" do

--- a/spec/fixtures/sample_solr_documents.yml
+++ b/spec/fixtures/sample_solr_documents.yml
@@ -1372,7 +1372,9 @@
   placename_coords:
   - Seoul (Korea)-|-37.566535-|-126.9779692
   - Korea (South)-|-35.907757-|-127.766922
-  place_bbox: 124.608139 33.1061096 130.9232178 38.6169312
+  place_bbox:
+  - 126.7645827 37.4259627 127.18359 37.7017495
+  - 124.608139 33.1061096 130.9232178 38.6169312
 - subtitle_display: dar khiradvarzī-i siyāsī va huvīyat-i mā Īrānīyān
   author_vern_display: "‏رجايى، فرهنگ ."
   subject_addl_t:

--- a/spec/lib/blacklight/maps/export_spec.rb
+++ b/spec/lib/blacklight/maps/export_spec.rb
@@ -19,7 +19,7 @@ describe "BlacklightMaps::GeojsonExport" do
     @request = ActionDispatch::TestRequest.new
     @controller.request = @request
     @response = ActionDispatch::TestResponse.new
-    @response.stub(:docs) {[{ "published_display"=>["Dharamsala, Distt. Kangra, H.P."], "pub_date"=>["2007"], "format"=>"Book", "title_display"=>"Ses yon", "material_type_display"=>["xii, 419 p."], "id"=>"2008308478", "subject_geo_facet"=>["China", "Tibet", "India"], "subject_topic_facet"=>["Education and state", "Tibetans", "Tibetan language", "Teaching"], "language_facet"=>["Tibetan"], "placename_coords"=>["China-|-35.86166-|-104.195397", "Tibet-|-29.646923-|-91.117212", "India-|-20.593684-|-78.96288"], "place_bbox"=>"68.162386 6.7535159 97.395555 35.5044752", "score"=>0.0026767207 }]}
+    @response.stub(:docs) {[{ "published_display"=>["Dharamsala, Distt. Kangra, H.P."], "pub_date"=>["2007"], "format"=>"Book", "title_display"=>"Ses yon", "material_type_display"=>["xii, 419 p."], "id"=>"2008308478", "subject_geo_facet"=>["China", "Tibet", "India"], "subject_topic_facet"=>["Education and state", "Tibetans", "Tibetan language", "Teaching"], "language_facet"=>["Tibetan"], "placename_coords"=>["China-|-35.86166-|-104.195397", "Tibet-|-29.646923-|-91.117212", "India-|-20.593684-|-78.96288"], "place_bbox"=>["68.162386 6.7535159 97.395555 35.5044752"], "score"=>0.0026767207 }]}
   end
 
   subject {BlacklightMaps::GeojsonExport.new(@controller, @response.docs)}


### PR DESCRIPTION
Fixes #17 

Enabling multiValued bounding box support via the Solr4 location_rpt field type.

Note, two bounding box locations can be seen Korea, Seoul and South Korea for the same document.

![screen shot 2014-03-20 at 6 23 21 pm](https://f.cloud.github.com/assets/1656824/2479427/71e475d4-b097-11e3-83fb-27b505d53969.png)
