### PR TITLE
add to_latlng method

### DIFF
--- a/lib/blacklight/maps/geometry.rb
+++ b/lib/blacklight/maps/geometry.rb
@@ -29,6 +29,11 @@ module BlacklightMaps
         center
       end
 
+      # Returns 2d array of latitude and longitude values for bounding box
+      def to_latlng
+        return [[@south, @west], [@north, @east]]
+      end
+
       # Creates a new bounding box from from a string of points
       # "-100 -50 100 50" (south west north east)
       def self.from_lon_lat_string(points)

--- a/spec/lib/blacklight/maps/geometry_spec.rb
+++ b/spec/lib/blacklight/maps/geometry_spec.rb
@@ -21,4 +21,8 @@ describe "BlacklightMaps::Geometry::BoundingBox" do
   it "should return correct dateline bounding box" do
     expect(bbox_dateline.find_center).to eq([-183.5, 5])
   end
+
+  it "should return 2d array of latitude longitude" do
+    expect(bbox_dateline.to_latlng).to eq([[30, 165], [-20, -172]])
+  end
 end


### PR DESCRIPTION
Adds a to_latlng method which returns a 2d array of lat,lng pairs for a bounding box
