### PR TITLE
Update how the 'X mapped' badge/text is shown

### DIFF
--- a/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
+++ b/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
@@ -4,7 +4,7 @@
     var map, sidebar, markers, geoJsonLayer, currentLayer;
 
     // Update page links with number of mapped items
-    $('.page_links').append(', <span class="badge">' + geojson_docs.features.length + '</span> mapped');
+    $('.page_links').append('<span class="badge mapped-count">' + geojson_docs.features.length + '</span> mapped');
 
     // Configure default options and those passed via the constructor options
     var options = $.extend({

--- a/app/assets/stylesheets/blacklight_maps/default.css.scss
+++ b/app/assets/stylesheets/blacklight_maps/default.css.scss
@@ -13,6 +13,11 @@
   height: 550px;
 }
 
+.badge.mapped-count {
+  margin-left: 8px;
+  vertical-align: text-bottom;
+}
+
 .sidebar-thumb{
   height: 64px;
   width: 64px;


### PR DESCRIPTION
The comma before the badge can look a bit odd, so this pull request:
- removes the comma
- adds a bit of margin before the "X mapped" badge
- vertically aligns the badge with the bottom of the text

![default_exhibit_-_blacklight_search_results](https://cloud.githubusercontent.com/assets/101482/2866251/70ababf0-d226-11e3-99d9-cc64135dd940.png)

![default_exhibit_-_blacklight_search_results 2](https://cloud.githubusercontent.com/assets/101482/2866254/74de222a-d226-11e3-9da6-b5e7cf8883fd.png)

![default_exhibit_-_blacklight_search_results 3](https://cloud.githubusercontent.com/assets/101482/2866255/781ca2cc-d226-11e3-93f3-4ca38caa2da3.png)
