### PR TITLE
Fix for preferred view in BL >=5.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ Blacklight-Maps expects you to provide these configuration options:
     + `placename_field` = the name of the Solr field containing the location names
 + `coordinates_field` = the name of the Solr `location_rpt` type field containing geospatial coordinate data
 
+In addition, you must add the geospatial facet field to the list of facet fields:
+```ruby
+config.add_facet_field 'geojson_field', :limit => -2, :label => 'Coordinates', :show => false
+```
+
 #### Optional
 
 - `show_initial_zoom` = the zoom level to be used in the catalog#show view map (zoom levels for catalog#map and catalog#index map views are computed automatically)
@@ -137,6 +142,8 @@ All of these options can easily be configured in `CatalogController.rb` in the `
     config.view.maps.mapattribution = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>'
     config.view.maps.maxzoom = 18
     config.view.maps.show_initial_zoom = 5
+
+    config.add_facet_field 'geojson', :limit => -2, :label => 'Coordinates', :show => false
 ...
 
 ```
@@ -173,7 +180,8 @@ Option | Type | Default | Description
 `searchcontrol` | Boolean | `false` | display the search control on the map
 `catalogpath` | String | `'catalog'` | the search path for the search control
 `placenamefield` | String | `'placename_field'` | the name of the Solr field containing the location names
-`searchctrlcue` | String | `'Search for all items within the current map window'` | the hover text to display when the mouse hovers over the search control
+`searchctrlcue` | String | `'Search for all items within the current map window'` | the hover text to display when the mouse hovers over the ![search control](docs/blacklight-maps_search-control.png) search control
+`searchresultsview` | String | `'list'` | the view type for the search results on the catalog#index page after the ![search control](docs/blacklight-maps_search-control.png) search control is used
 `singlemarkermode` | Boolean | `true` | whether locations should be clustered
 `clustercount` | String | `'locations'` | whether clusters should display the location count or the number of hits (`'hits'` or `'locations'`)
 `maxzoom` | Integer | 18 | the maxZoom [property of the map](http://leafletjs.com/reference.html#map-maxzoom)

--- a/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
+++ b/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
@@ -14,7 +14,8 @@
       searchctrlcue: 'Search for all items within the current map window',
       placenamefield: 'placename_field',
       nodata: 'Sorry, there is no data for this location.',
-      clustercount:'locations'
+      clustercount:'locations',
+      searchresultsview: 'list'
     }, arg_opts );
 
     // Extend options from data-attributes
@@ -196,7 +197,7 @@
             return Math.round(parseFloat(coord) * 1000000) / 1000000;
           }),
           coordinate_params = '[' + bounds[1] + ',' + bounds[0] + ' TO ' + bounds[3] + ',' + bounds[2] + ']';
-      params.push('coordinates=' + encodeURIComponent(coordinate_params), 'spatial_search_type=bbox');
+      params.push('coordinates=' + encodeURIComponent(coordinate_params), 'spatial_search_type=bbox', 'view=' + options.searchresultsview);
       $(location).attr('href', options.catalogpath + '?' + params.join('&'));
     }
 

--- a/app/helpers/blacklight/blacklight_maps_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_maps_helper_behavior.rb
@@ -27,7 +27,8 @@ module Blacklight::BlacklightMapsHelperBehavior
     coords_for_search = bbox_coordinates.map { |v| v.to_s }
     link_to(t('blacklight.maps.interactions.bbox_search'),
             catalog_index_path(spatial_search_type: "bbox",
-                               coordinates: "[#{coords_for_search[1]},#{coords_for_search[0]} TO #{coords_for_search[3]},#{coords_for_search[2]}]"))
+                               coordinates: "[#{coords_for_search[1]},#{coords_for_search[0]} TO #{coords_for_search[3]},#{coords_for_search[2]}]",
+                               view: default_document_index_view_type))
   end
 
   # create a link to a location name facet value
@@ -37,8 +38,9 @@ module Blacklight::BlacklightMapsHelperBehavior
     else
       new_params = add_facet_params(field, field_value)
     end
+    new_params[:view] = default_document_index_view_type
     link_to(displayvalue.presence || field_value,
-            catalog_index_path(new_params.except(:view, :id, :spatial_search_type, :coordinates)))
+            catalog_index_path(new_params.except(:id, :spatial_search_type, :coordinates)))
   end
 
   # create a link to a spatial search for a set of point coordinates
@@ -46,6 +48,7 @@ module Blacklight::BlacklightMapsHelperBehavior
     new_params = params.except(:controller, :action, :view, :id, :spatial_search_type, :coordinates)
     new_params[:spatial_search_type] = "point"
     new_params[:coordinates] = "#{point_coordinates[1]},#{point_coordinates[0]}"
+    new_params[:view] = default_document_index_view_type
     link_to(t('blacklight.maps.interactions.point_search'), catalog_index_path(new_params))
   end
 

--- a/app/views/catalog/_index_map.html.erb
+++ b/app/views/catalog/_index_map.html.erb
@@ -2,6 +2,7 @@
                        {data:{searchcontrol: true,
                               catalogpath: catalog_index_path,
                               placenamefield: blacklight_config.view.maps.placename_field,
-                              clustercount:'hits'
+                              clustercount:'hits',
+                              searchresultsview: default_document_index_view_type
                        }}) %>
 <%= javascript_tag "$('#blacklight-index-map').blacklight_leaflet_map(#{geojson_features});" %>

--- a/spec/features/maps_spec.rb
+++ b/spec/features/maps_spec.rb
@@ -108,6 +108,10 @@ describe "Map View", js: true do
             expect(page).to have_selector(".constraint-value .filterValue", text: "Seoul (Korea)")
           end
 
+          it "should use the default view type" do
+            expect(current_url).to include("view=list")
+          end
+
         end
 
       end
@@ -134,6 +138,7 @@ describe "Map View", js: true do
 
           it "should run a new search" do
             expect(page).to have_selector(".constraint.coordinates")
+            expect(current_url).to include("view=list")
           end
 
         end
@@ -183,6 +188,7 @@ describe "Map View", js: true do
 
           it "should run a new search" do
             expect(page).to have_selector(".constraint-value .filterValue", text: "35.86166,104.195397")
+            expect(current_url).to include("view=list")
           end
 
         end

--- a/spec/helpers/blacklight_maps_helper_spec.rb
+++ b/spec/helpers/blacklight_maps_helper_spec.rb
@@ -65,10 +65,16 @@ describe BlacklightMapsHelper do
   end
 
   describe "link_to_bbox_search" do
+
     it "should create a spatial search link" do
       expect(helper.link_to_bbox_search(bbox)).to include('catalog?coordinates')
       expect(helper.link_to_bbox_search(bbox)).to include('spatial_search_type=bbox')
     end
+
+    it "should include the default_document_index_view_type in the params" do
+      expect(helper.link_to_bbox_search(bbox)).to include('view=list')
+    end
+
   end
 
   describe "link_to_placename_field" do
@@ -81,13 +87,23 @@ describe BlacklightMapsHelper do
       expect(helper.link_to_placename_field('Tibet', blacklight_config.view.maps.placename_field, 'foo')).to include('">foo</a>')
     end
 
+    it "should include the default_document_index_view_type in the params" do
+      expect(helper.link_to_placename_field('Tibet', blacklight_config.view.maps.placename_field)).to include('view=list')
+    end
+
   end
 
   describe "link_to_point_search" do
+
     it "should create a link to a coordinate point" do
       expect(helper.link_to_point_search(coords)).to include('catalog?coordinates')
       expect(helper.link_to_point_search(coords)).to include('spatial_search_type=point')
     end
+
+    it "should include the default_document_index_view_type in the params" do
+      expect(helper.link_to_point_search(coords)).to include('view=list')
+    end
+
   end
 
   describe "map_facet_field" do


### PR DESCRIPTION
This PR addresses a change introduced in BL 5.8.0, where the params[:view] value is pulled from the user's session if no value is explicitly passed in the params hash.

For map views, since the previous view will always be 'map', the params[:view] value must be explicitly set in the Leaflet popup "view items from this location" search links and search control, or the user will never actually get to view the search results, just another map.

Whenever possible, the ```default_document_index_view_type``` is used to set the params[:view] value.

This PR also includes a bit more clarification of config requirements in the README.md.