### PR TITLE
use options.initialzoom for catalog#show maplet view

### DIFF
--- a/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
+++ b/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
@@ -7,7 +7,7 @@
     var options = $.extend({
       tileurl : 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
       mapattribution : 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
-      initialZoom: 2,
+      initialzoom: 2,
       singlemarkermode: true,
       searchcontrol: false,
       catalogpath: 'catalog',
@@ -68,7 +68,6 @@
       // Setup Leaflet map
       map = L.map(this.id, {
         center: [0, 0],
-        zoom: options.initialZoom
       });
 
       L.tileLayer(options.tileurl, {
@@ -147,12 +146,18 @@
 
     /**
     * Sets the view of the map, based off of the map bounds
+    * options.initialzoom is invoked for catalog#show views (unless it would obscure features)
     */
     function setMapBounds() {
       map.fitBounds(mapBounds(), {
         padding: [10, 10],
         maxZoom: options.maxzoom
       });
+      if ($('#document').length) {
+        if (map.getZoom() > options.initialzoom) {
+          map.setZoom(options.initialzoom)
+        }
+      }
     }
 
     /**

--- a/config/jetty.yml
+++ b/config/jetty.yml
@@ -3,5 +3,5 @@ development:
   jetty_port: 8983 
 test:
   startup_wait: 60
-  jetty_port: <%= ENV['TEST_JETTY_PORT'] || 8888 %>
+  jetty_port: <%= ENV['TEST_JETTY_PORT'] || 8983 %>
   <%= ENV['TEST_JETTY_PATH'] ? "jetty_home: " + ENV['TEST_JETTY_PATH'] : '' %>

--- a/spec/features/show_view_maplet_spec.rb
+++ b/spec/features/show_view_maplet_spec.rb
@@ -72,8 +72,9 @@ describe "catalog#show view", js: true do
 
     before :each do
       CatalogController.configure_blacklight do |config|
-        # set maxzoom so we can test whether initial zoom is correct
+        # set zoom config so we can test whether setMapBounds() is correct
         config.view.maps.maxzoom = 8
+        config.view.maps.show_initial_zoom = 10
       end
       visit solr_document_path("2009373514")
     end
@@ -83,7 +84,7 @@ describe "catalog#show view", js: true do
     end
 
     it "should zoom to the correct map bounds" do
-      # if initial zoom >= maxzoom, zoom-in control will be disabled
+      # if setMapBounds() zoom >= maxzoom, zoom-in control will be disabled
       expect(page).to have_selector(".leaflet-control-zoom-in.leaflet-disabled")
     end
 


### PR DESCRIPTION
This PR restores some previous functionality that got removed with the introduction of the `setMapBounds()` function in https://github.com/projectblacklight/blacklight-maps/commit/1d27c849d350c2977f85773dd6966f1a60f5732f, which is the ability to set the zoom level for the catalog#show maplet through the `config.view.maps.show_initial_zoom` setting.

The `setMapBounds()` function now checks if the script is being called on a catalog#show page, and sets the zoom level to the config value (unless the config zoom level is too deep for all features to be shown in the maplet).
