### PR TITLE
Add new locale files

### DIFF
--- a/config/locales/blacklight-maps-zh.yml
+++ b/config/locales/blacklight-maps-zh.yml
@@ -1,0 +1,20 @@
+zh:
+  blacklight:
+
+    maps:
+      interactions:
+        bbox_search: 'View items that intersect with this bounding box'
+        placename_search: 'View items from this location'
+        item: '资料'
+        point_search: 'View items from this location'
+        search_ctrl_cue: 'Search for all items within the current map window'
+      title: '地图'
+      leader: 'Click on a marker to search for items from that location.'
+
+    search:
+      filters:
+        coordinates:
+          bbox: 'Bounding Box'
+          point: 'Coordinates'
+      view:
+        maps: '地图'

--- a/config/locales/blacklight-maps.it.yml
+++ b/config/locales/blacklight-maps.it.yml
@@ -1,0 +1,20 @@
+it:
+  blacklight:
+
+    maps:
+      interactions:
+        bbox_search: 'View items that intersect with this bounding box'
+        placename_search: 'View items from this location'
+        item: 'item'
+        point_search: 'View items from this location'
+        search_ctrl_cue: 'Search for all items within the current map window'
+      title: 'Mappa'
+      leader: 'Click on a marker to search for items from that location.'
+
+    search:
+      filters:
+        coordinates:
+          bbox: 'Bounding Box'
+          point: 'Coordinates'
+      view:
+        maps: 'Mappa'


### PR DESCRIPTION
Adds locale files for Chinese and Italian. Only the strings that are currently shown in Spotlight (the mouseover label for the Map icon) are translated, because it didn't seem reasonable to ask our current translators to provide translations for strings not shown in the application they're concerned with. 